### PR TITLE
Allow individual sensors to be customised in the Lovelace UI

### DIFF
--- a/custom_components/xiaomi_miio_cooker/__init__.py
+++ b/custom_components/xiaomi_miio_cooker/__init__.py
@@ -177,6 +177,7 @@ class XiaomiMiioDevice(Entity):
         self._available = None
         self._state = None
         self._state_attrs = {}
+        self._unique_id = DOMAIN
 
     @property
     def should_poll(self):
@@ -202,6 +203,11 @@ class XiaomiMiioDevice(Entity):
     def extra_state_attributes(self):
         """Return the extra state attributes of the device."""
         return self._state_attrs
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
 
 
 #    async def _try_command(self, mask_error, func, *args, **kwargs):

--- a/custom_components/xiaomi_miio_cooker/sensor.py
+++ b/custom_components/xiaomi_miio_cooker/sensor.py
@@ -62,10 +62,12 @@ class XiaomiCookerSensor(Entity):
         self._unit_of_measurement = config[3]
         self._icon = config[4]
         self._state = None
+        self._state_attributes = {}
 
         self.entity_id = ENTITY_ID_FORMAT.format(
             "{}_{}".format(COOKER_DOMAIN, slugify(self._name))
         )
+        self._unique_id = COOKER_DOMAIN + self.entity_id
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -97,6 +99,7 @@ class XiaomiCookerSensor(Entity):
             # Unset state if child attribute isn't available anymore
             if state is None:
                 self._state = None
+                self._state_attributes[self._name] = None
 
         if state is not None:
             value = getattr(state, self._attr, None)
@@ -110,8 +113,10 @@ class XiaomiCookerSensor(Entity):
                     and temperature_history
                 ):
                     self._state = temperature_history.temperatures.pop()
+                    self._state_attributes[self._name] = temperature_history.temperatures.pop()
                 else:
                     self._state = value
+                    self._state_attributes[self._name] = value
 
         self.async_schedule_update_ha_state()
 
@@ -134,3 +139,13 @@ class XiaomiCookerSensor(Entity):
     def should_poll(self):
         """Return the polling state."""
         return False
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the sensor."""
+        return self._state_attributes


### PR DESCRIPTION
This fixes #47 allowing individual sensors to be customised in the Lovelace UI.

Ideally, this would be based off of the MAC Address of the device as it is static, whereas the Host IP Address and the Token can change. However, it is instead based off of the Domain of the integration so could conflict if there are multiple rice cookers. I'm open to suggestions on how to change this from Domain to MAC Address.

Thank you