### PR TITLE
fix: python 3.11 support (Home Assistant 2023.06.0)

### DIFF
--- a/custom_components/xiaomi_miio_cooker/sensor.py
+++ b/custom_components/xiaomi_miio_cooker/sensor.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from enum import Enum
 from typing import Optional
@@ -67,8 +66,7 @@ class XiaomiCookerSensor(Entity):
             "{}_{}".format(COOKER_DOMAIN, slugify(self._name))
         )
 
-    @asyncio.coroutine
-    def async_added_to_hass(self):
+    async def async_added_to_hass(self):
         """Register callbacks."""
         self.hass.helpers.dispatcher.async_dispatcher_connect(
             "{}_updated".format(COOKER_DOMAIN), self.async_update_callback


### PR DESCRIPTION
Closes: #65 

Just updated and noticed that the integration does not load.

This is due to the fact that Home Assistant now ships with Python 3.11 which removed the `@asnycio.coroutine`.

Ref: https://github.com/python/cpython/issues/87382