### PR TITLE
Fix manifest.json key order for hassfest

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["prettier-plugin-sort-json"],
+  "jsonSortOrder": "{\"domain\": 0, \"name\": 1, \"*\": \"lexical\"}"
+}

--- a/custom_components/xiaomi_miio_cooker/manifest.json
+++ b/custom_components/xiaomi_miio_cooker/manifest.json
@@ -1,17 +1,12 @@
 {
   "domain": "xiaomi_miio_cooker",
   "name": "Xiaomi Mi Electric Rice Cooker",
-  "codeowners": [
-    "@syssi"
-  ],
+  "codeowners": ["@syssi"],
   "config_flow": false,
   "dependencies": [],
   "documentation": "https://github.com/syssi/xiaomi_cooker",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/syssi/xiaomi_cooker/issues",
-  "requirements": [
-    "construct==2.10.68",
-    "python-miio>=0.5.12"
-  ],
+  "requirements": ["construct==2.10.68", "python-miio>=0.5.12"],
   "version": "2025.5.0.0"
 }


### PR DESCRIPTION
## Problem

`prettier-plugin-sort-json` (added in `modernize-project-setup`) sorts all JSON keys purely alphabetically. This moves `domain` to position 5 and `name` to position 8 in `manifest.json`. hassfest requires `domain` → `name` → alphabetical and fails with:

```
[MANIFEST] Manifest keys are not sorted correctly: domain, name, then alphabetical order
```

## Fix

- Add `.prettierrc.json` with `jsonSortOrder` pinning `domain` to position 0, `name` to position 1, everything else lexical
- Restore `manifest.json` to the correct HA key order